### PR TITLE
Hover対応のデバイスだけ:hoverを有効にする

### DIFF
--- a/assets/stylesheets/bootstrap/_badges.scss
+++ b/assets/stylesheets/bootstrap/_badges.scss
@@ -59,10 +59,12 @@
 
 // Hover state, but only for links
 a.badge {
-  &:hover,
-  &:focus {
-    color: $badge-link-hover-color;
-    text-decoration: none;
-    cursor: pointer;
+  @include hover-support {
+    &:hover,
+    &:focus {
+      color: $badge-link-hover-color;
+      text-decoration: none;
+      cursor: pointer;
+    }
   }
 }

--- a/assets/stylesheets/bootstrap/_buttons.scss
+++ b/assets/stylesheets/bootstrap/_buttons.scss
@@ -113,11 +113,13 @@ a.btn {
   &:active {
     border-color: transparent;
   }
-  &:hover,
-  &:focus {
-    color: $link-hover-color;
-    text-decoration: $link-hover-decoration;
-    background-color: transparent;
+  @include hover-support {
+    &:hover,
+    &:focus {
+      color: $link-hover-color;
+      text-decoration: $link-hover-decoration;
+      background-color: transparent;
+    }
   }
   &[disabled],
   fieldset[disabled] & {

--- a/assets/stylesheets/bootstrap/_buttons.scss
+++ b/assets/stylesheets/bootstrap/_buttons.scss
@@ -17,7 +17,6 @@
   background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
   border: 1px solid transparent;
   white-space: nowrap;
-  text-decoration: none;
   @include button-size($padding-base-vertical, $padding-base-horizontal, $font-size-base, $line-height-base, $btn-border-radius-base);
   @include user-select(none);
 

--- a/assets/stylesheets/bootstrap/_buttons.scss
+++ b/assets/stylesheets/bootstrap/_buttons.scss
@@ -17,6 +17,7 @@
   background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
   border: 1px solid transparent;
   white-space: nowrap;
+  text-decoration: none;
   @include button-size($padding-base-vertical, $padding-base-horizontal, $font-size-base, $line-height-base, $btn-border-radius-base);
   @include user-select(none);
 
@@ -29,11 +30,12 @@
     }
   }
 
-  &:hover,
-  &:focus,
-  &.focus {
-    color: $btn-default-color;
-    text-decoration: none;
+  @include hover-support {
+    &:hover,
+    &:focus,
+    &.focus {
+      color: $btn-default-color;
+    }
   }
 
   &:active,

--- a/assets/stylesheets/bootstrap/_carousel.scss
+++ b/assets/stylesheets/bootstrap/_carousel.scss
@@ -116,12 +116,14 @@
   }
 
   // Hover/focus state
-  &:hover,
-  &:focus {
-    outline: 0;
-    color: $carousel-control-color;
-    text-decoration: none;
-    @include opacity(.9);
+  @include hover-support {
+    &:hover,
+    &:focus {
+      outline: 0;
+      color: $carousel-control-color;
+      text-decoration: none;
+      @include opacity(.9);
+    }
   }
 
   // Toggles

--- a/assets/stylesheets/bootstrap/_close.scss
+++ b/assets/stylesheets/bootstrap/_close.scss
@@ -12,12 +12,14 @@
   text-shadow: $close-text-shadow;
   @include opacity(.2);
 
-  &:hover,
-  &:focus {
-    color: $close-color;
-    text-decoration: none;
-    cursor: pointer;
-    @include opacity(.5);
+  @include hover-support {
+    &:hover,
+    &:focus {
+      color: $close-color;
+      text-decoration: none;
+      cursor: pointer;
+      @include opacity(.5);
+    }
   }
 
   // [converter] extracted button& to button.close

--- a/assets/stylesheets/bootstrap/_labels.scss
+++ b/assets/stylesheets/bootstrap/_labels.scss
@@ -30,11 +30,13 @@
 
 // Add hover effects, but only for links
 a.label {
-  &:hover,
-  &:focus {
-    color: $label-link-hover-color;
-    text-decoration: none;
-    cursor: pointer;
+  @include hover-support {
+    &:hover,
+    &:focus {
+      color: $label-link-hover-color;
+      text-decoration: none;
+      cursor: pointer;
+    }
   }
 }
 

--- a/assets/stylesheets/bootstrap/_list-group.scss
+++ b/assets/stylesheets/bootstrap/_list-group.scss
@@ -52,11 +52,13 @@ button.list-group-item {
   }
 
   // Hover state
-  &:hover,
-  &:focus {
-    text-decoration: none;
-    color: $list-group-link-hover-color;
-    background-color: $list-group-hover-bg;
+  @include hover-support {
+    &:hover,
+    &:focus {
+      text-decoration: none;
+      color: $list-group-link-hover-color;
+      background-color: $list-group-hover-bg;
+    }
   }
 }
 

--- a/assets/stylesheets/bootstrap/_mixins.scss
+++ b/assets/stylesheets/bootstrap/_mixins.scss
@@ -2,6 +2,7 @@
 // --------------------------------------------------
 
 // Utilities
+@import 'mixins/hover';
 @import "mixins/hide-text";
 @import "mixins/opacity";
 @import "mixins/image";

--- a/assets/stylesheets/bootstrap/_navbar.scss
+++ b/assets/stylesheets/bootstrap/_navbar.scss
@@ -400,10 +400,12 @@
 
   .navbar-brand {
     color: $navbar-default-brand-color;
-    &:hover,
-    &:focus {
-      color: $navbar-default-brand-hover-color;
-      background-color: $navbar-default-brand-hover-bg;
+    @include hover-support {
+      &:hover,
+      &:focus {
+        color: $navbar-default-brand-hover-color;
+        background-color: $navbar-default-brand-hover-bg;
+      }
     }
   }
 
@@ -415,10 +417,12 @@
     > li > a {
       color: $navbar-default-link-color;
 
-      &:hover,
-      &:focus {
-        color: $navbar-default-link-hover-color;
-        background-color: $navbar-default-link-hover-bg;
+      @include hover-support {
+        &:hover,
+        &:focus {
+          color: $navbar-default-link-hover-color;
+          background-color: $navbar-default-link-hover-bg;
+        }
       }
     }
     > .active > a {
@@ -441,9 +445,11 @@
 
   .navbar-toggle {
     border-color: $navbar-default-toggle-border-color;
-    &:hover,
-    &:focus {
-      background-color: $navbar-default-toggle-hover-bg;
+    @include hover-support {
+      &:hover,
+      &:focus {
+        background-color: $navbar-default-toggle-hover-bg;
+      }
     }
     .icon-bar {
       background-color: $navbar-default-toggle-icon-bar-bg;
@@ -472,10 +478,12 @@
       .open .dropdown-menu {
         > li > a {
           color: $navbar-default-link-color;
-          &:hover,
-          &:focus {
-            color: $navbar-default-link-hover-color;
-            background-color: $navbar-default-link-hover-bg;
+          @include hover-support {
+            &:hover,
+            &:focus {
+              color: $navbar-default-link-hover-color;
+              background-color: $navbar-default-link-hover-bg;
+            }
           }
         }
         > .active > a {
@@ -512,9 +520,11 @@
 
   .btn-link {
     color: $navbar-default-link-color;
-    &:hover,
-    &:focus {
-      color: $navbar-default-link-hover-color;
+    @include hover-support {
+      &:hover,
+      &:focus {
+        color: $navbar-default-link-hover-color;
+      }
     }
     &[disabled],
     fieldset[disabled] & {
@@ -534,10 +544,12 @@
 
   .navbar-brand {
     color: $navbar-inverse-brand-color;
-    &:hover,
-    &:focus {
-      color: $navbar-inverse-brand-hover-color;
-      background-color: $navbar-inverse-brand-hover-bg;
+    @include hover-support {
+      &:hover,
+      &:focus {
+        color: $navbar-inverse-brand-hover-color;
+        background-color: $navbar-inverse-brand-hover-bg;
+      }
     }
   }
 
@@ -548,11 +560,12 @@
   .navbar-nav {
     > li > a {
       color: $navbar-inverse-link-color;
-
-      &:hover,
-      &:focus {
-        color: $navbar-inverse-link-hover-color;
-        background-color: $navbar-inverse-link-hover-bg;
+      @include hover-support {
+        &:hover,
+        &:focus {
+          color: $navbar-inverse-link-hover-color;
+          background-color: $navbar-inverse-link-hover-bg;
+        }
       }
     }
     > .active > a {
@@ -576,9 +589,11 @@
   // Darken the responsive nav toggle
   .navbar-toggle {
     border-color: $navbar-inverse-toggle-border-color;
-    &:hover,
-    &:focus {
-      background-color: $navbar-inverse-toggle-hover-bg;
+    @include hover-support {
+      &:hover,
+      &:focus {
+        background-color: $navbar-inverse-toggle-hover-bg;
+      }
     }
     .icon-bar {
       background-color: $navbar-inverse-toggle-icon-bar-bg;
@@ -612,10 +627,12 @@
         }
         > li > a {
           color: $navbar-inverse-link-color;
-          &:hover,
-          &:focus {
-            color: $navbar-inverse-link-hover-color;
-            background-color: $navbar-inverse-link-hover-bg;
+          @include hover-support {
+            &:hover,
+            &:focus {
+              color: $navbar-inverse-link-hover-color;
+              background-color: $navbar-inverse-link-hover-bg;
+            }
           }
         }
         > .active > a {
@@ -640,16 +657,20 @@
 
   .navbar-link {
     color: $navbar-inverse-link-color;
-    &:hover {
-      color: $navbar-inverse-link-hover-color;
+    @include hover-support {
+      &:hover {
+        color: $navbar-inverse-link-hover-color;
+      }
     }
   }
 
   .btn-link {
     color: $navbar-inverse-link-color;
-    &:hover,
-    &:focus {
-      color: $navbar-inverse-link-hover-color;
+    @include hover-support {
+      &:hover,
+      &:focus {
+        color: $navbar-inverse-link-hover-color;
+      }
     }
     &[disabled],
     fieldset[disabled] & {

--- a/assets/stylesheets/bootstrap/_navs.scss
+++ b/assets/stylesheets/bootstrap/_navs.scss
@@ -48,15 +48,11 @@
 
   // Open dropdowns
   .open > a {
-    background-color: $nav-link-hover-bg;
-    border-color: $link-color;
-
-    @include hover-support {
-      &:hover,
-      &:focus {
-        background-color: $nav-link-hover-bg;
-        border-color: $link-color;
-      }
+    &,
+    &:hover,
+    &:focus {
+      background-color: $nav-link-hover-bg;
+      border-color: $link-color;
     }
   }
 
@@ -105,21 +101,14 @@
 
     // Active state, and its :hover to override normal :hover
     &.active > a {
-      color: $nav-tabs-active-link-hover-color;
-      background-color: $nav-tabs-active-link-hover-bg;
-      border: 1px solid $nav-tabs-active-link-hover-border-color;
-      border-bottom-color: transparent;
-      cursor: default;
-
-      @include hover-support {
-        &:hover,
-        &:focus {
-          color: $nav-tabs-active-link-hover-color;
-          background-color: $nav-tabs-active-link-hover-bg;
-          border: 1px solid $nav-tabs-active-link-hover-border-color;
-          border-bottom-color: transparent;
-          cursor: default;
-        }
+      &,
+      &:hover,
+      &:focus {
+        color: $nav-tabs-active-link-hover-color;
+        background-color: $nav-tabs-active-link-hover-bg;
+        border: 1px solid $nav-tabs-active-link-hover-border-color;
+        border-bottom-color: transparent;
+        cursor: default;
       }
     }
   }

--- a/assets/stylesheets/bootstrap/_navs.scss
+++ b/assets/stylesheets/bootstrap/_navs.scss
@@ -147,9 +147,7 @@
 
     // Active state
     &.active > a {
-      color: $nav-pills-active-link-hover-color;
-      background-color: $nav-pills-active-link-hover-bg;
-
+      &,
       &:hover,
       &:focus {
         color: $nav-pills-active-link-hover-color;

--- a/assets/stylesheets/bootstrap/_navs.scss
+++ b/assets/stylesheets/bootstrap/_navs.scss
@@ -20,10 +20,13 @@
       position: relative;
       display: block;
       padding: $nav-link-padding;
-      &:hover,
-      &:focus {
-        text-decoration: none;
-        background-color: $nav-link-hover-bg;
+
+      @include hover-support {
+        &:hover,
+        &:focus {
+          text-decoration: none;
+          background-color: $nav-link-hover-bg;
+        }
       }
     }
 
@@ -31,23 +34,29 @@
     &.disabled > a {
       color: $nav-disabled-link-color;
 
-      &:hover,
-      &:focus {
-        color: $nav-disabled-link-hover-color;
-        text-decoration: none;
-        background-color: transparent;
-        cursor: $cursor-disabled;
+      @include hover-support {
+        &:hover,
+        &:focus {
+          color: $nav-disabled-link-hover-color;
+          text-decoration: none;
+          background-color: transparent;
+          cursor: $cursor-disabled;
+        }
       }
     }
   }
 
   // Open dropdowns
   .open > a {
-    &,
-    &:hover,
-    &:focus {
-      background-color: $nav-link-hover-bg;
-      border-color: $link-color;
+    background-color: $nav-link-hover-bg;
+    border-color: $link-color;
+
+    @include hover-support {
+      &:hover,
+      &:focus {
+        background-color: $nav-link-hover-bg;
+        border-color: $link-color;
+      }
     }
   }
 
@@ -86,21 +95,31 @@
       line-height: $line-height-base;
       border: 1px solid transparent;
       border-radius: $border-radius-base $border-radius-base 0 0;
-      &:hover {
-        border-color: $nav-tabs-link-hover-border-color $nav-tabs-link-hover-border-color $nav-tabs-border-color;
+
+      @include hover-support {
+        &:hover {
+          border-color: $nav-tabs-link-hover-border-color $nav-tabs-link-hover-border-color $nav-tabs-border-color;
+        }
       }
     }
 
     // Active state, and its :hover to override normal :hover
     &.active > a {
-      &,
-      &:hover,
-      &:focus {
-        color: $nav-tabs-active-link-hover-color;
-        background-color: $nav-tabs-active-link-hover-bg;
-        border: 1px solid $nav-tabs-active-link-hover-border-color;
-        border-bottom-color: transparent;
-        cursor: default;
+      color: $nav-tabs-active-link-hover-color;
+      background-color: $nav-tabs-active-link-hover-bg;
+      border: 1px solid $nav-tabs-active-link-hover-border-color;
+      border-bottom-color: transparent;
+      cursor: default;
+
+      @include hover-support {
+        &:hover,
+        &:focus {
+          color: $nav-tabs-active-link-hover-color;
+          background-color: $nav-tabs-active-link-hover-bg;
+          border: 1px solid $nav-tabs-active-link-hover-border-color;
+          border-bottom-color: transparent;
+          cursor: default;
+        }
       }
     }
   }
@@ -128,7 +147,9 @@
 
     // Active state
     &.active > a {
-      &,
+      color: $nav-pills-active-link-hover-color;
+      background-color: $nav-pills-active-link-hover-bg;
+
       &:hover,
       &:focus {
         color: $nav-pills-active-link-hover-color;

--- a/assets/stylesheets/bootstrap/_pagination.scss
+++ b/assets/stylesheets/bootstrap/_pagination.scss
@@ -38,12 +38,14 @@
 
   > li > a,
   > li > span {
-    &:hover,
-    &:focus {
-      z-index: 2;
-      color: $pagination-hover-color;
-      background-color: $pagination-hover-bg;
-      border-color: $pagination-hover-border;
+    @include hover-support {
+      &:hover,
+      &:focus {
+        z-index: 2;
+        color: $pagination-hover-color;
+        background-color: $pagination-hover-bg;
+        border-color: $pagination-hover-border;
+      }
     }
   }
 

--- a/assets/stylesheets/bootstrap/_scaffolding.scss
+++ b/assets/stylesheets/bootstrap/_scaffolding.scss
@@ -49,10 +49,11 @@ a {
   color: $link-color;
   text-decoration: none;
 
-  &:hover,
-  &:focus {
-    color: $link-hover-color;
-    text-decoration: $link-hover-decoration;
+  @include hover-support {
+    &:hover,
+    &:focus {
+      color: $link-hover-color;
+    }
   }
 
   &:focus {

--- a/assets/stylesheets/bootstrap/_tables.scss
+++ b/assets/stylesheets/bootstrap/_tables.scss
@@ -121,9 +121,11 @@ th {
 //
 // Placed here since it has to come after the potential zebra striping
 
-.table-hover {
-  > tbody > tr:hover {
-    background-color: $table-bg-hover;
+@include hover-support {
+  .table-hover {
+    > tbody > tr:hover {
+      background-color: $table-bg-hover;
+    }
   }
 }
 

--- a/assets/stylesheets/bootstrap/_theme.scss
+++ b/assets/stylesheets/bootstrap/_theme.scss
@@ -51,10 +51,12 @@
   background-repeat: repeat-x;
   border-color: darken($btn-color, 14%);
 
-  &:hover,
-  &:focus  {
-    background-color: darken($btn-color, 12%);
-    background-position: 0 -15px;
+  @include hover-support {
+    &:hover,
+    &:focus  {
+      background-color: darken($btn-color, 12%);
+      background-position: 0 -15px;
+    }
   }
 
   &:active,

--- a/assets/stylesheets/bootstrap/_theme.scss
+++ b/assets/stylesheets/bootstrap/_theme.scss
@@ -112,10 +112,12 @@
 // Dropdowns
 // --------------------------------------------------
 
-.dropdown-menu > li > a:hover,
-.dropdown-menu > li > a:focus {
-  @include gradient-vertical($start-color: $dropdown-link-hover-bg, $end-color: darken($dropdown-link-hover-bg, 5%));
-  background-color: darken($dropdown-link-hover-bg, 5%);
+@include hover-support {
+  .dropdown-menu > li > a:hover,
+  .dropdown-menu > li > a:focus {
+    @include gradient-vertical($start-color: $dropdown-link-hover-bg, $end-color: darken($dropdown-link-hover-bg, 5%));
+    background-color: darken($dropdown-link-hover-bg, 5%);
+  }
 }
 .dropdown-menu > .active > a,
 .dropdown-menu > .active > a:hover,

--- a/assets/stylesheets/bootstrap/_thumbnails.scss
+++ b/assets/stylesheets/bootstrap/_thumbnails.scss
@@ -31,8 +31,12 @@
 }
 
 // Add a hover state for linked versions only
-a.thumbnail:hover,
-a.thumbnail:focus,
+@include hover-support {
+  a.thumbnail:hover,
+  a.thumbnail:focus {
+    border-color: $link-color;
+  }
+}
 a.thumbnail.active {
   border-color: $link-color;
 }

--- a/assets/stylesheets/bootstrap/mixins/_background-variant.scss
+++ b/assets/stylesheets/bootstrap/mixins/_background-variant.scss
@@ -5,8 +5,10 @@
   #{$parent} {
     background-color: $color;
   }
-  a#{$parent}:hover,
-  a#{$parent}:focus {
-    background-color: darken($color, 10%);
+  @include hover-support {
+    a#{$parent}:hover,
+    a#{$parent}:focus {
+      background-color: darken($color, 10%);
+    }
   }
 }

--- a/assets/stylesheets/bootstrap/mixins/_buttons.scss
+++ b/assets/stylesheets/bootstrap/mixins/_buttons.scss
@@ -3,8 +3,6 @@
 // Easily pump out default styles, as well as :hover, :focus, :active,
 // and disabled options for all buttons
 
-@import 'hover';
-
 @mixin button-variant($color, $background, $border) {
   color: $color;
   background-color: $background;
@@ -44,13 +42,11 @@
   &.disabled,
   &[disabled],
   fieldset[disabled] & {
-    @include hover-support {
-      &:hover,
-      &:focus,
-      &.focus {
-        background-color: $background;
-            border-color: $border;
-      }
+    &:hover,
+    &:focus,
+    &.focus {
+      background-color: $background;
+          border-color: $border;
     }
   }
 

--- a/assets/stylesheets/bootstrap/mixins/_buttons.scss
+++ b/assets/stylesheets/bootstrap/mixins/_buttons.scss
@@ -3,21 +3,21 @@
 // Easily pump out default styles, as well as :hover, :focus, :active,
 // and disabled options for all buttons
 
+@import 'hover';
+
 @mixin button-variant($color, $background, $border) {
   color: $color;
   background-color: $background;
   border-color: $border;
 
-  &:focus,
-  &.focus {
-    color: $color;
-    background-color: darken($background, 10%);
-        border-color: darken($border, 25%);
-  }
-  &:hover {
-    color: $color;
-    background-color: darken($background, 10%);
-        border-color: darken($border, 12%);
+  @include hover-support {
+    &:hover,
+    &:focus,
+    &.focus {
+      color: $color;
+      background-color: darken($background, 10%);
+          border-color: darken($border, 12%);
+    }
   }
   &:active,
   &.active,
@@ -26,12 +26,14 @@
     background-color: darken($background, 10%);
         border-color: darken($border, 12%);
 
-    &:hover,
-    &:focus,
-    &.focus {
-      color: $color;
-      background-color: darken($background, 17%);
-          border-color: darken($border, 25%);
+    @include hover-support {
+      &:hover,
+      &:focus,
+      &.focus {
+        color: $color;
+        background-color: darken($background, 17%);
+            border-color: darken($border, 25%);
+      }
     }
   }
   &:active,
@@ -42,11 +44,13 @@
   &.disabled,
   &[disabled],
   fieldset[disabled] & {
-    &:hover,
-    &:focus,
-    &.focus {
-      background-color: $background;
-          border-color: $border;
+    @include hover-support {
+      &:hover,
+      &:focus,
+      &.focus {
+        background-color: $background;
+            border-color: $border;
+      }
     }
   }
 

--- a/assets/stylesheets/bootstrap/mixins/_hover.scss
+++ b/assets/stylesheets/bootstrap/mixins/_hover.scss
@@ -1,0 +1,5 @@
+@mixin hover-support {
+  @media (hover: hover), (-moz-touch-enabled: 0) {
+    @content;
+  }
+}

--- a/assets/stylesheets/bootstrap/mixins/_labels.scss
+++ b/assets/stylesheets/bootstrap/mixins/_labels.scss
@@ -3,10 +3,12 @@
 @mixin label-variant($color) {
   background-color: $color;
 
-  &[href] {
-    &:hover,
-    &:focus {
-      background-color: darken($color, 10%);
+  @include hover-support {
+    &[href] {
+      &:hover,
+      &:focus {
+        background-color: darken($color, 10%);
+      }
     }
   }
 }

--- a/assets/stylesheets/bootstrap/mixins/_list-group.scss
+++ b/assets/stylesheets/bootstrap/mixins/_list-group.scss
@@ -16,10 +16,12 @@
       color: inherit;
     }
 
-    &:hover,
-    &:focus {
-      color: $color;
-      background-color: darken($background, 5%);
+    @include hover-support {
+      &:hover,
+      &:focus {
+        color: $color;
+        background-color: darken($background, 5%);
+      }
     }
     &.active,
     &.active:hover,

--- a/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss
+++ b/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss
@@ -5,8 +5,10 @@
   #{$parent} {
     color: $color;
   }
-  a#{$parent}:hover,
-  a#{$parent}:focus {
-    color: darken($color, 10%);
+  @include hover-support {
+    a#{$parent}:hover,
+    a#{$parent}:focus {
+      color: darken($color, 10%);
+    }
   }
 }


### PR DESCRIPTION
タッチデバイスでは、:hoverはタップ後に残り続けるので、すべて無効化します。
同様に:focusも不要なので無効化します。

以下のようなパターンの場合は、残っても問題ないのでそのままとします。
（以下の場合、`.active`状態の場合、自分とhoverとfocusすべてに同じスタイルをあてています）

```css
    &.active > a {
      &,
      &:hover,
      &:focus {
        color: $nav-tabs-active-link-hover-color;
        background-color: $nav-tabs-active-link-hover-bg;
        border: 1px solid $nav-tabs-active-link-hover-border-color;
        border-bottom-color: transparent;
        cursor: default;
      }
    }
```