### PR TITLE
Support $link-hover-decoration varialble

### DIFF
--- a/assets/stylesheets/bootstrap/_buttons.scss
+++ b/assets/stylesheets/bootstrap/_buttons.scss
@@ -34,6 +34,7 @@
     &:focus,
     &.focus {
       color: $btn-default-color;
+      text-decoration: none;
     }
   }
 

--- a/assets/stylesheets/bootstrap/_scaffolding.scss
+++ b/assets/stylesheets/bootstrap/_scaffolding.scss
@@ -53,6 +53,7 @@ a {
     &:hover,
     &:focus {
       color: $link-hover-color;
+      text-decoration: $link-hover-decoration;
     }
   }
 


### PR DESCRIPTION
「Hover対応のデバイスだけ:hoverを有効にする #1 」で
$link-hover-decorationへの対応を消してしまっていたので復活します

#1 と比べてもらえるとわかりますが、消したものを戻しただけです。
$link-hover-decoration はaタグのhover時の挙動を決めるもので、デフォルトはunderlineでした。
hover時のunderlineはなしでよいかな、と思ったけど、landingページ等で使うときの汎用性を考慮してこのオプションがちゃんと使えるようにします