### PR TITLE
Remove button link style

### DIFF
--- a/assets/stylesheets/bootstrap/_button-groups.scss
+++ b/assets/stylesheets/bootstrap/_button-groups.scss
@@ -115,11 +115,6 @@
 // Remove the gradient and set the same inset shadow as the :active state
 .btn-group.open .dropdown-toggle {
   @include box-shadow(inset 0 3px 5px rgba(0,0,0,.125));
-
-  // Show no shadow for `.btn-link` since it has no other button styles.
-  &.btn-link {
-    @include box-shadow(none);
-  }
 }
 
 

--- a/assets/stylesheets/bootstrap/_buttons.scss
+++ b/assets/stylesheets/bootstrap/_buttons.scss
@@ -90,49 +90,6 @@ a.btn {
   @include button-variant($btn-danger-color, $btn-danger-bg, $btn-danger-border);
 }
 
-
-// Link buttons
-// -------------------------
-
-// Make a button look and behave like a link
-.btn-link {
-  color: $link-color;
-  font-weight: normal;
-  border-radius: 0;
-
-  &,
-  &:active,
-  &.active,
-  &[disabled],
-  fieldset[disabled] & {
-    background-color: transparent;
-    @include box-shadow(none);
-  }
-  &,
-  &:hover,
-  &:focus,
-  &:active {
-    border-color: transparent;
-  }
-  @include hover-support {
-    &:hover,
-    &:focus {
-      color: $link-hover-color;
-      text-decoration: $link-hover-decoration;
-      background-color: transparent;
-    }
-  }
-  &[disabled],
-  fieldset[disabled] & {
-    &:hover,
-    &:focus {
-      color: $btn-link-disabled-color;
-      text-decoration: none;
-    }
-  }
-}
-
-
 // Button Sizes
 // --------------------------------------------------
 

--- a/assets/stylesheets/bootstrap/_navbar.scss
+++ b/assets/stylesheets/bootstrap/_navbar.scss
@@ -517,23 +517,6 @@
       color: $navbar-default-link-hover-color;
     }
   }
-
-  .btn-link {
-    color: $navbar-default-link-color;
-    @include hover-support {
-      &:hover,
-      &:focus {
-        color: $navbar-default-link-hover-color;
-      }
-    }
-    &[disabled],
-    fieldset[disabled] & {
-      &:hover,
-      &:focus {
-        color: $navbar-default-link-disabled-color;
-      }
-    }
-  }
 }
 
 // Inverse navbar
@@ -660,23 +643,6 @@
     @include hover-support {
       &:hover {
         color: $navbar-inverse-link-hover-color;
-      }
-    }
-  }
-
-  .btn-link {
-    color: $navbar-inverse-link-color;
-    @include hover-support {
-      &:hover,
-      &:focus {
-        color: $navbar-inverse-link-hover-color;
-      }
-    }
-    &[disabled],
-    fieldset[disabled] & {
-      &:hover,
-      &:focus {
-        color: $navbar-inverse-link-disabled-color;
       }
     }
   }


### PR DESCRIPTION
Boostrapには、buttonを普通のテキストリンク風に見せるbtn-linkというクラスがある。おそらくセマンティック的にaよりbuttonが適切な場合で使うのだと思うが、削除する。

理由
- このクラスを使ったことがないし、将来的に使うイメージもないのでなくなっても困らない
- buttonは、デフォルトで枠がついてくるが、それを無効化するのに苦労していて余計なコードが増える原因になっている
- Scrapboxでは、ActionLink というコンポーネントをもっていて、こちらをdropdown menu内などで使っている。この用途で、btn-linkは使えない...


[![Screenshot from Gyazo](https://gyazo.com/b40cf5fc58e4a92f0bdb58ec2bde5537/raw)](https://gyazo.com/b40cf5fc58e4a92f0bdb58ec2bde5537)