### PR TITLE
dropdown menuにactive要素をつける

### DIFF
--- a/assets/stylesheets/bootstrap/_buttons.scss
+++ b/assets/stylesheets/bootstrap/_buttons.scss
@@ -42,6 +42,7 @@
   &.active {
     outline: 0;
     background-image: none;
+    text-decoration: none;
     @include box-shadow(inset 0 3px 5px rgba(0,0,0,.125));
   }
 

--- a/assets/stylesheets/bootstrap/_dropdowns.scss
+++ b/assets/stylesheets/bootstrap/_dropdowns.scss
@@ -70,16 +70,25 @@
     line-height: $line-height-base;
     color: $dropdown-link-color;
     white-space: nowrap; // prevent links from randomly breaking onto new lines
+    @include user-select(none);
   }
 }
 
 // Hover/Focus state
 .dropdown-menu > li > a {
-  &:hover,
-  &:focus {
+  &:active {
     text-decoration: none;
     color: $dropdown-link-hover-color;
     background-color: $dropdown-link-hover-bg;
+  }
+
+  @include hover-support {
+    &:hover,
+    &:focus {
+      text-decoration: none;
+      color: $dropdown-link-hover-color;
+      background-color: $dropdown-link-hover-bg;
+    }
   }
 }
 
@@ -87,6 +96,7 @@
 .dropdown-menu > .active > a {
   &,
   &:hover,
+  &:active,
   &:focus {
     color: $dropdown-link-active-color;
     text-decoration: none;
@@ -102,12 +112,14 @@
 .dropdown-menu > .disabled > a {
   &,
   &:hover,
+  &:active,
   &:focus {
     color: $dropdown-link-disabled-color;
   }
 
-  // Nuke hover/focus effects
+  // Nuke hover/active/focus effects
   &:hover,
+  &:active,
   &:focus {
     text-decoration: none;
     background-color: transparent;

--- a/assets/stylesheets/bootstrap/_navbar.scss
+++ b/assets/stylesheets/bootstrap/_navbar.scss
@@ -236,6 +236,7 @@
     padding-top:    10px;
     padding-bottom: 10px;
     line-height: $line-height-computed;
+    @include user-select(none);
   }
 
   @media (max-width: $grid-float-breakpoint-max) {
@@ -400,6 +401,10 @@
 
   .navbar-brand {
     color: $navbar-default-brand-color;
+    &:active {
+      color: $navbar-default-brand-hover-color;
+      background-color: $navbar-default-brand-hover-bg;
+    }
     @include hover-support {
       &:hover,
       &:focus {
@@ -416,7 +421,10 @@
   .navbar-nav {
     > li > a {
       color: $navbar-default-link-color;
-
+      &:active {
+        color: $navbar-default-link-hover-color;
+        background-color: $navbar-default-link-hover-bg;
+      }
       @include hover-support {
         &:hover,
         &:focus {
@@ -428,6 +436,7 @@
     > .active > a {
       &,
       &:hover,
+      &:active,
       &:focus {
         color: $navbar-default-link-active-color;
         background-color: $navbar-default-link-active-bg;
@@ -436,6 +445,7 @@
     > .disabled > a {
       &,
       &:hover,
+      &:active,
       &:focus {
         color: $navbar-default-link-disabled-color;
         background-color: $navbar-default-link-disabled-bg;
@@ -445,6 +455,9 @@
 
   .navbar-toggle {
     border-color: $navbar-default-toggle-border-color;
+    &:active {
+      background-color: $navbar-default-toggle-hover-bg;
+    }
     @include hover-support {
       &:hover,
       &:focus {
@@ -467,6 +480,7 @@
     > .open > a {
       &,
       &:hover,
+      &:active,
       &:focus {
         background-color: $navbar-default-link-active-bg;
         color: $navbar-default-link-active-color;
@@ -478,6 +492,10 @@
       .open .dropdown-menu {
         > li > a {
           color: $navbar-default-link-color;
+          &:active {
+            color: $navbar-default-link-hover-color;
+            background-color: $navbar-default-link-hover-bg;
+          }
           @include hover-support {
             &:hover,
             &:focus {
@@ -489,6 +507,7 @@
         > .active > a {
           &,
           &:hover,
+          &:active,
           &:focus {
             color: $navbar-default-link-active-color;
             background-color: $navbar-default-link-active-bg;
@@ -497,6 +516,7 @@
         > .disabled > a {
           &,
           &:hover,
+          &:active,
           &:focus {
             color: $navbar-default-link-disabled-color;
             background-color: $navbar-default-link-disabled-bg;
@@ -544,6 +564,10 @@
 
   .navbar-brand {
     color: $navbar-inverse-brand-color;
+    &:active {
+      color: $navbar-inverse-brand-hover-color;
+      background-color: $navbar-inverse-brand-hover-bg;
+    }
     @include hover-support {
       &:hover,
       &:focus {
@@ -560,6 +584,10 @@
   .navbar-nav {
     > li > a {
       color: $navbar-inverse-link-color;
+      &:active {
+        color: $navbar-inverse-link-hover-color;
+        background-color: $navbar-inverse-link-hover-bg;
+      }
       @include hover-support {
         &:hover,
         &:focus {
@@ -589,6 +617,9 @@
   // Darken the responsive nav toggle
   .navbar-toggle {
     border-color: $navbar-inverse-toggle-border-color;
+    &:active {
+      background-color: $navbar-inverse-toggle-hover-bg;
+    }
     @include hover-support {
       &:hover,
       &:focus {
@@ -627,6 +658,10 @@
         }
         > li > a {
           color: $navbar-inverse-link-color;
+          &:active {
+            color: $navbar-inverse-link-hover-color;
+            background-color: $navbar-inverse-link-hover-bg;
+          }
           @include hover-support {
             &:hover,
             &:focus {
@@ -638,6 +673,7 @@
         > .active > a {
           &,
           &:hover,
+          &:active,
           &:focus {
             color: $navbar-inverse-link-active-color;
             background-color: $navbar-inverse-link-active-bg;
@@ -646,6 +682,7 @@
         > .disabled > a {
           &,
           &:hover,
+          &:active,
           &:focus {
             color: $navbar-inverse-link-disabled-color;
             background-color: $navbar-inverse-link-disabled-bg;

--- a/assets/stylesheets/bootstrap/mixins/_labels.scss
+++ b/assets/stylesheets/bootstrap/mixins/_labels.scss
@@ -3,8 +3,11 @@
 @mixin label-variant($color) {
   background-color: $color;
 
-  @include hover-support {
-    &[href] {
+  &[href] {
+    &:active {
+      background-color: darken($color, 10%);
+    }
+    @include hover-support {
       &:hover,
       &:focus {
         background-color: darken($color, 10%);


### PR DESCRIPTION
これまでDropdown menuには、hover要素しかなかったが、これではタッチデバイスで厳密には理想的に動かない。（特にDrawerなど出っぱなしになるような場所で使われたときに、hover状態が残ってしまう）

そこでbuttonなどと同じように、タッチデバイスではhoverは無効にし、active状態を新たに定義することにします。