### PR TITLE
<select>の見た目を統一

### DIFF
--- a/assets/stylesheets/bootstrap/_forms.scss
+++ b/assets/stylesheets/bootstrap/_forms.scss
@@ -134,12 +134,6 @@ output {
   // Placeholder
   @include placeholder;
 
-  // Unstyle the caret on `<select>`s in IE10+.
-  &::-ms-expand {
-    border: 0;
-    background-color: transparent;
-  }
-
   // Disabled and read-only inputs
   //
   // HTML5 says that controls under a fieldset > legend:first-child won't be
@@ -229,8 +223,9 @@ select.form-control {
   -moz-appearance: none;
   appearance: none;
 
+  // Unstyle the caret on `<select>`s in IE10+.
   &::-ms-expand {
-    display: none; // for IE 10-11
+    display: none;
   }
 }
 

--- a/assets/stylesheets/bootstrap/_forms.scss
+++ b/assets/stylesheets/bootstrap/_forms.scss
@@ -91,7 +91,6 @@ output {
   color: $input-color;
 }
 
-
 // Common form controls
 //
 // Shared size and type resets for form controls. Apply `.form-control` to any
@@ -217,6 +216,22 @@ input[type="search"] {
 
 .form-group {
   margin-bottom: $form-group-margin-bottom;
+}
+
+// Select
+select.form-control {
+  padding-right: 24px;
+  $double-arrow: "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'><path fill='#343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/></svg>";
+  background: $input-bg svg-uri($double-arrow) no-repeat right .75rem center;
+  background-size: 8px 10px;
+
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+
+  &::-ms-expand {
+    display: none; // for IE 10-11
+  }
 }
 
 

--- a/assets/stylesheets/bootstrap/_mixins.scss
+++ b/assets/stylesheets/bootstrap/_mixins.scss
@@ -12,6 +12,7 @@
 @import "mixins/size";
 @import "mixins/tab-focus";
 @import "mixins/reset-text";
+@import "mixins/svg-uri";
 @import "mixins/text-emphasis";
 @import "mixins/text-overflow";
 @import "mixins/vendor-prefixes";

--- a/assets/stylesheets/bootstrap/mixins/_forms.scss
+++ b/assets/stylesheets/bootstrap/mixins/_forms.scss
@@ -62,9 +62,7 @@
 // Form control sizing
 //
 // Relative text size, padding, and border-radii changes for form controls. For
-// horizontal sizing, wrap controls in the predefined grid classes. `<select>`
-// element gets special love because it's special, and that's a fact!
-// [converter] $parent hack
+// horizontal sizing, wrap controls in the predefined grid classes.
 @mixin input-size($parent, $input-height, $padding-vertical, $padding-horizontal, $font-size, $line-height, $border-radius) {
   #{$parent} {
     height: $input-height;
@@ -72,11 +70,6 @@
     font-size: $font-size;
     line-height: $line-height;
     border-radius: $border-radius;
-  }
-
-  select#{$parent} {
-    height: $input-height;
-    line-height: $input-height;
   }
 
   textarea#{$parent},

--- a/assets/stylesheets/bootstrap/mixins/_svg-uri.scss
+++ b/assets/stylesheets/bootstrap/mixins/_svg-uri.scss
@@ -1,0 +1,48 @@
+////
+/// Helper function to easily use an SVG inline in CSS
+/// without encoding it to base64, saving bytes.
+/// It also helps with browser support.
+////
+
+/// A small function allowing skipping base64 encoding
+/// and simply pasting the SVG markup right in the CSS.
+/// @author Jakob Eriksen
+/// @link http://codepen.io/jakob-e/pen/doMoML
+/// @param {String} $svg - SVG image to encode
+/// @return {String} - Encoded SVG data uri
+@function svg-uri($svg) {
+    $encoded: '';
+    $slice: 2000;
+    $index: 0;
+    $loops: ceil(str-length($svg) / $slice);
+
+    @for $i from 1 through $loops {
+        $chunk: str-slice($svg, $index, $index + $slice - 1);
+        $chunk: str-replace($chunk, '"', "'");
+        $chunk: str-replace($chunk, '<', '%3C');
+        $chunk: str-replace($chunk, '>', '%3E');
+        $chunk: str-replace($chunk, '&', '%26');
+        $chunk: str-replace($chunk, '#', '%23');
+        $encoded: #{$encoded}#{$chunk};
+        $index: $index + $slice;
+    }
+
+    @return url("data:image/svg+xml;charset=utf8,#{$encoded}");
+}
+
+/// Replace `$search` with `$replace` in `$string`
+/// @author Hugo Giraudel
+/// @link http://sassmeister.com/gist/1b4f2da5527830088e4d
+/// @param {String} $string - Initial string
+/// @param {String} $search - Substring to replace
+/// @param {String} $replace ('') - New value
+/// @return {String} - Updated string
+@function str-replace($string, $search, $replace: '') {
+    $index: str-index($string, $search);
+
+    @if $index {
+        @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
+    }
+
+    @return $string;
+}

--- a/demo/tatami/src/client/js/components/forms.js
+++ b/demo/tatami/src/client/js/components/forms.js
@@ -90,6 +90,22 @@ export default function Forms () {
           <input className='form-control input-sm' type='text' placeholder='.input-sm' />
         </div>
 
+        <div className='form-group'>
+          <select className="form-control input-lg">
+            <option>Large select</option>
+          </select>
+        </div>
+        <div className='form-group'>
+          <select className="form-control">
+            <option>Default select</option>
+          </select>
+        </div>
+        <div className='form-group'>
+          <select className="form-control input-sm">
+            <option>Small select</option>
+          </select>
+        </div>
+
         <h3>Input groups</h3>
 
         <div className='input-group input-group-lg'>


### PR DESCRIPTION
Select ボックスの見た目を全部ブラウザで統一します。

これまでは、Firefox, IE, Edge, iOS, AndroidすべてでそれぞれのOSの見た目になっていました。
特にiOSで、変化が大きいです。

@mountainboooy レビューお願いします
