### PR TITLE
radioとcheckをcustom design化しつつform-inlineをflex化

### DIFF
--- a/assets/stylesheets/bootstrap/_forms.scss
+++ b/assets/stylesheets/bootstrap/_forms.scss
@@ -562,12 +562,6 @@ input[type="checkbox"] {
       width: auto;
     }
 
-    .control-label {
-      margin-bottom: 0;
-      margin-right: 5px;
-      padding-top: 0;
-    }
-
     // Remove default margin on radios/checkboxes that were used for stacking
     .radio,
     .checkbox {

--- a/assets/stylesheets/bootstrap/_forms.scss
+++ b/assets/stylesheets/bootstrap/_forms.scss
@@ -47,13 +47,6 @@ input[type="search"] {
   @include box-sizing(border-box);
 }
 
-// Position radios and checkboxes better
-input[type="radio"],
-input[type="checkbox"] {
-  margin: 4px 0 0;
-  line-height: normal;
-}
-
 input[type="file"] {
   display: block;
 }
@@ -71,12 +64,11 @@ select[size] {
 }
 
 // Focus for file, radio, and checkbox
-input[type="file"],
 input[type="radio"],
-input[type="checkbox"] {
+input[type="checkbox"],
+input[type="file"] {
   [data-use-focus] &:focus {
-    // Note: box shadow does not work on Safari, so use outline for focus
-    @include tab-focus-outline;
+    @include tab-focus;
   }
 }
 
@@ -123,7 +115,7 @@ output {
   background-color: $input-bg;
   background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
   border: 1px solid $input-border;
-  border-radius: $input-border-radius; // Note: This has no effect on <select>s in some browsers, due to the limited stylability of <select>s in CSS.
+  border-radius: $input-border-radius;
   @include transition(border-color ease-in-out .15s, box-shadow ease-in-out .15s);
 
   // Customize the `:focus` state to imitate native WebKit styles.
@@ -230,29 +222,73 @@ select.form-control {
 
 // Checkboxes and radios
 //
-// Indent the labels to position radios/checkboxes as hanging controls.
+// Custom design can be applied except for IE11
 
 .radio,
 .checkbox {
-  position: relative;
-  display: block;
   margin-top: 10px;
   margin-bottom: 10px;
 
   label {
-    min-height: $line-height-computed; // Ensure the input doesn't jump when there is no text
-    padding-left: 20px;
+    display: flex;
     margin-bottom: 0;
     font-weight: normal;
     cursor: pointer;
   }
 }
-.radio input[type="radio"],
-.radio-inline input[type="radio"],
-.checkbox input[type="checkbox"],
-.checkbox-inline input[type="checkbox"] {
-  position: absolute;
-  margin-left: -20px;
+
+.radio,
+.radio-inline {
+  input[type="radio"] {
+    border-radius: 50%;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    margin: 0 5px 0 0;
+    cursor: pointer;
+    border: 1px solid $input-border;
+    background-color: $input-bg;
+    transition: background .3s, border-color .3s, box-shadow .3s;
+
+    &:checked {
+      border: 6px solid $link-color;
+
+      [data-use-focus] &:focus {
+        border-color: $link-color; // override tab-focus
+      }
+    }
+  }
+}
+
+.checkbox,
+.checkbox-inline {
+  input[type="checkbox"] {
+    border-radius: $input-border-radius;
+    appearance: none;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    flex-shrink: 0;
+    width: 18px;
+    height: 18px;
+    margin: 0 5px 0 0;
+    cursor: pointer;
+    border: 1px solid $input-border;
+    background-color: $input-bg;
+    transition: background-color .3s, border-color .3s, box-shadow .3s;
+
+    &:checked {
+      border-color: $link-color;
+      background-color: $link-color;
+      $checkbox-svg: "<svg xmlns='http://www.w3.org/2000/svg' viewBox='8 8 36 36' version='1.1' xml:space='preserve'><path d='M14.1 27.2l7.1 7.2 16.7-16.8' fill='none' stroke='rgba(255,255,255,1)' stroke-width='5'/></svg>";
+      background-image: svg-uri($checkbox-svg);
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: 90%;
+    }
+  }
 }
 
 .radio + .radio,
@@ -263,9 +299,7 @@ select.form-control {
 // Radios and checkboxes on same line
 .radio-inline,
 .checkbox-inline {
-  position: relative;
-  display: inline-block;
-  padding-left: 20px;
+  display: inline-flex;
   margin-bottom: 0;
   vertical-align: middle;
   font-weight: normal;
@@ -287,6 +321,7 @@ input[type="checkbox"] {
   &.disabled,
   fieldset[disabled] & {
     cursor: $cursor-disabled;
+    background-color: $input-bg-disabled;
   }
 }
 // These classes are used directly on <label>s
@@ -470,43 +505,51 @@ input[type="checkbox"] {
 
 // Inline forms
 //
-// Make forms appear inline(-block) by adding the `.form-inline` class. Inline
+// Make forms appear inline by adding the `.form-inline` class. Inline
 // forms begin stacked on extra small (mobile) devices and then go inline when
 // viewports reach <768px.
 //
 // Requires wrapping inputs and labels with `.form-group` for proper display of
 // default HTML form controls and our custom form controls (e.g., input groups).
 //
-// Heads up! This is mixin-ed into `.navbar-form` in navbars.less.
+// Heads up! This is mixin-ed into `.navbar-form` in navbars.
 
-// [converter] extracted from `.form-inline` for libsass compatibility
 @mixin form-inline {
 
   // Kick in the inline
   @media (min-width: $screen-sm-min) {
-    // Inline-block all the things for "inline"
+    display: flex;
+    align-items: center;
+
+    > *:nth-child(n+2) {
+      margin-left: 5px;
+    }
+
+    // flex all the things for "inline"
     .form-group {
-      display: inline-block;
+      display: flex;
+      align-items: center;
       margin-bottom: 0;
-      vertical-align: middle;
+
+      label {
+        margin-bottom: 0;
+        margin-right: 5px;
+      }
     }
 
     // In navbar-form, allow folks to *not* use `.form-group`
     .form-control {
-      display: inline-block;
       width: auto; // Prevent labels from stacking above inputs in `.form-group`
-      vertical-align: middle;
     }
 
     // Make static controls behave like regular ones
     .form-control-static {
-      display: inline-block;
+      padding-top: 0;
+      padding-bottom: 0;
+      min-height: auto;
     }
 
     .input-group {
-      display: inline-table;
-      vertical-align: middle;
-
       .input-group-addon,
       .input-group-btn,
       .form-control {
@@ -516,31 +559,20 @@ input[type="checkbox"] {
 
     // Input groups need that 100% width though
     .input-group > .form-control {
-      width: 100%;
+      width: auto;
     }
 
     .control-label {
       margin-bottom: 0;
-      vertical-align: middle;
+      margin-right: 5px;
+      padding-top: 0;
     }
 
-    // Remove default margin on radios/checkboxes that were used for stacking, and
-    // then undo the floating of radios and checkboxes to match.
+    // Remove default margin on radios/checkboxes that were used for stacking
     .radio,
     .checkbox {
-      display: inline-block;
       margin-top: 0;
       margin-bottom: 0;
-      vertical-align: middle;
-
-      label {
-        padding-left: 0;
-      }
-    }
-    .radio input[type="radio"],
-    .checkbox input[type="checkbox"] {
-      position: relative;
-      margin-left: 0;
     }
 
     // Re-override the feedback icon.
@@ -549,7 +581,7 @@ input[type="checkbox"] {
     }
   }
 }
-// [converter] extracted as `@mixin form-inline` for libsass compatibility
+
 .form-inline {
   @include form-inline;
 }

--- a/assets/stylesheets/bootstrap/_forms.scss
+++ b/assets/stylesheets/bootstrap/_forms.scss
@@ -208,10 +208,7 @@ select.form-control {
   $double-arrow: "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'><path fill='#343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/></svg>";
   background: $input-bg svg-uri($double-arrow) no-repeat right .75rem center;
   background-size: 8px 10px;
-
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
+  @include appearance(none);
 
   // Unstyle the caret on `<select>`s in IE10+.
   &::-ms-expand {
@@ -240,10 +237,8 @@ select.form-control {
 .radio,
 .radio-inline {
   input[type="radio"] {
+    @include appearance(none);
     border-radius: 50%;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
     flex-shrink: 0;
     width: 20px;
     height: 20px;
@@ -266,10 +261,8 @@ select.form-control {
 .checkbox,
 .checkbox-inline {
   input[type="checkbox"] {
+    @include appearance(none);
     border-radius: $input-border-radius;
-    appearance: none;
-    -moz-appearance: none;
-    -webkit-appearance: none;
     flex-shrink: 0;
     width: 18px;
     height: 18px;
@@ -521,8 +514,8 @@ input[type="checkbox"] {
     display: flex;
     align-items: center;
 
-    > *:nth-child(n+2) {
-      margin-left: 5px;
+    > *:not(:last-child) {
+      margin-right: 5px;
     }
 
     // flex all the things for "inline"
@@ -544,8 +537,6 @@ input[type="checkbox"] {
 
     // Make static controls behave like regular ones
     .form-control-static {
-      padding-top: 0;
-      padding-bottom: 0;
       min-height: auto;
     }
 

--- a/assets/stylesheets/bootstrap/_forms.scss
+++ b/assets/stylesheets/bootstrap/_forms.scss
@@ -219,7 +219,6 @@ select.form-control {
 
 // Checkboxes and radios
 //
-// Custom design can be applied except for IE11
 
 .radio,
 .checkbox {
@@ -248,8 +247,18 @@ select.form-control {
     background-color: $input-bg;
     transition: background .3s, border-color .3s, box-shadow .3s;
 
+    &::-ms-check  { // for IE11 (not Edge)
+      border: 1px solid $input-border;
+      background-color: $input-bg;
+      color: transparent; // remove color of preset inner circle style
+    }
+
     &:checked {
       border: 6px solid $link-color;
+
+      &::-ms-check  { // for IE11 (not Edge)
+        border: 6px solid $link-color;
+      }
 
       [data-use-focus] &:focus {
         border-color: $link-color; // override tab-focus
@@ -272,14 +281,26 @@ select.form-control {
     background-color: $input-bg;
     transition: background-color .3s, border-color .3s, box-shadow .3s;
 
+    &::-ms-check { // for IE11 (not Edge)
+      border: 1px solid $input-border;
+      border-radius: $input-border-radius;
+      background-color: $input-bg;
+      color: transparent; // remove color of preset check mark style
+    }
+
+    $checkbox-svg: "<svg xmlns='http://www.w3.org/2000/svg' viewBox='8 8 36 36' version='1.1' xml:space='preserve'><path d='M14.1 27.2l7.1 7.2 16.7-16.8' fill='none' stroke='rgba(255,255,255,1)' stroke-width='5'/></svg>";
+
     &:checked {
       border-color: $link-color;
-      background-color: $link-color;
-      $checkbox-svg: "<svg xmlns='http://www.w3.org/2000/svg' viewBox='8 8 36 36' version='1.1' xml:space='preserve'><path d='M14.1 27.2l7.1 7.2 16.7-16.8' fill='none' stroke='rgba(255,255,255,1)' stroke-width='5'/></svg>";
-      background-image: svg-uri($checkbox-svg);
-      background-repeat: no-repeat;
-      background-position: center;
+      background: $link-color svg-uri($checkbox-svg) no-repeat center;
       background-size: 90%;
+
+      // we can not mix ::-ms-check and :checked in the same line
+      &::-ms-check { // for IE11 (not Edge)
+        border-color: $link-color;
+        background: $link-color svg-uri($checkbox-svg) no-repeat center;
+        background-size: 90%;
+      }
     }
   }
 }
@@ -315,6 +336,10 @@ input[type="checkbox"] {
   fieldset[disabled] & {
     cursor: $cursor-disabled;
     background-color: $input-bg-disabled;
+
+    &::-ms-check { // for IE11 (not Edge)
+      background-color: $input-bg-disabled;
+    }
   }
 }
 // These classes are used directly on <label>s

--- a/assets/stylesheets/bootstrap/_forms.scss
+++ b/assets/stylesheets/bootstrap/_forms.scss
@@ -64,9 +64,9 @@ select[size] {
 }
 
 // Focus for file, radio, and checkbox
+input[type="file"],
 input[type="radio"],
-input[type="checkbox"],
-input[type="file"] {
+input[type="checkbox"] {
   [data-use-focus] &:focus {
     @include tab-focus;
   }

--- a/assets/stylesheets/bootstrap/mixins/_tab-focus.scss
+++ b/assets/stylesheets/bootstrap/mixins/_tab-focus.scss
@@ -5,8 +5,3 @@
   border-color: $input-border-focus;
   @include transition(border-color ease-in-out .15s, box-shadow ease-in-out .15s);
 }
-
-@mixin tab-focus-outline() {
-  $color-rgba: rgba(red($input-border-focus), green($input-border-focus), blue($input-border-focus), .6);
-  outline: 3px solid $color-rgba;
-}

--- a/assets/stylesheets/bootstrap/mixins/_vendor-prefixes.scss
+++ b/assets/stylesheets/bootstrap/mixins/_vendor-prefixes.scss
@@ -4,6 +4,7 @@
 // Autoprefixer in our Gruntfile. They have been removed in v4.
 
 // - Animations
+// - Appearance
 // - Backface visibility
 // - Box shadow
 // - Box sizing
@@ -39,6 +40,13 @@
 }
 @mixin animation-fill-mode($fill-mode) {
   animation-fill-mode: $fill-mode;
+}
+
+// Appearance
+@mixin appearance($style) {
+          appearance: $style;
+  -webkit-appearance: $style;
+     -moz-appearance: $style;
 }
 
 // Backface visibility

--- a/demo/tatami/src/client/js/components/forms.js
+++ b/demo/tatami/src/client/js/components/forms.js
@@ -49,9 +49,19 @@ export default function Forms () {
           <label className='control-label' htmlFor='freetext'>Free text</label>
           <textarea className='form-control' id='freetext'  />
         </div>
+
+        <br />
+
+        <h3>Checkboxes and radios</h3>
+        <h4>Default (stacked)</h4>
         <div className='checkbox'>
           <label>
             <input type='checkbox' /> Check me out
+          </label>
+        </div>
+        <div className='checkbox'>
+          <label>
+            <input type='checkbox'  disabled /> Disabled check
           </label>
         </div>
         <div className='radio'>
@@ -66,6 +76,41 @@ export default function Forms () {
             Option two can be something else and selecting it will deselect option one
           </label>
         </div>
+        <div className='radio'>
+          <label>
+            <input type='radio' name='optionsRadios' id='optionsRadios2' value='option2' disabled />
+            This option is disabled
+          </label>
+        </div>
+
+        <br />
+        <h4>Inline checkboxes and radios</h4>
+        <div className='form-group'>
+          <label className='checkbox-inline'>
+            <input type='checkbox' id='inlineCheckbox1' value='option1' /> 1
+          </label>
+          <label className='checkbox-inline'>
+            <input type='checkbox' id='inlineCheckbox2' value='option2' /> 2
+          </label>
+          <label className='checkbox-inline'>
+            <input type='checkbox' id='inlineCheckbox3' value='option3' /> 3
+          </label>
+        </div>
+
+        <div className='form-group'>
+          some text {' '}
+          <label className='radio-inline'>
+            <input type='radio' name='inlineRadioOptions' id='inlineRadio1' value='option1' /> 1
+          </label>
+          <label className='radio-inline'>
+            <input type='radio' name='inlineRadioOptions' id='inlineRadio2' value='option2' /> 2
+          </label>
+          <label className='radio-inline'>
+            <input type='radio' name='inlineRadioOptions' id='inlineRadio3' value='option3' /> 3
+          </label>
+        </div>
+        <br />
+        <br />
 
         <div className='form-group'>
           <label htmlFor='slider'>Process nice score from -20 to +20</label>
@@ -91,17 +136,17 @@ export default function Forms () {
         </div>
 
         <div className='form-group'>
-          <select className="form-control input-lg">
+          <select className='form-control input-lg'>
             <option>Large select</option>
           </select>
         </div>
         <div className='form-group'>
-          <select className="form-control">
+          <select className='form-control'>
             <option>Default select</option>
           </select>
         </div>
         <div className='form-group'>
-          <select className="form-control input-sm">
+          <select className='form-control input-sm'>
             <option>Small select</option>
           </select>
         </div>
@@ -184,6 +229,77 @@ export default function Forms () {
           </div>
           <div className='panel-footer'>
             Footer
+          </div>
+        </div>
+      </form>
+
+      <br />
+      <h2>Inline form</h2>
+      <form className='form-inline'>
+        <div className='form-group'>
+          <label for='exampleInputName2'>Name</label>
+          <input type='text' className='form-control' id='exampleInputName2' placeholder='Jane Doe' />
+        </div>
+        <div className='form-group'>
+          <label for='exampleInputEmail2'>Email</label>
+          <input type='email' className='form-control' id='exampleInputEmail2' placeholder='jane.doe@example.com' />
+        </div>
+        <div className='form-group'>
+          <p className='form-control-static'>note</p>
+        </div>
+        <div className='checkbox'>
+          <label>
+            <input type='checkbox' /> Remember me
+          </label>
+        </div>
+        <button type='submit' className='btn btn-default'>Send invitation</button>
+      </form>
+
+      <form className='form-inline'>
+        <div className='form-group'>
+          <input type='text' className='form-control' id='exampleInputName2' placeholder='Jane Doe' />
+        </div>
+        <div className='form-group'>
+          <input type='email' className='form-control' id='exampleInputEmail2' placeholder='jane.doe@example.com' />
+        </div>
+        <div className='input-group'>
+          <span className='input-group-addon' id='sizing-addon2'>@</span>
+          <input type='text' className='form-control' placeholder='Username' aria-describedby='sizing-addon2' />
+          <span className='input-group-addon'>.00</span>
+        </div>
+        <div className='form-group'>
+          <p className='form-control-static'>note</p>
+        </div>
+        <button type='submit' className='btn btn-default'>Send invitation</button>
+      </form>
+
+      <br />
+      <h2>Horizontal form</h2>
+      <form className='form-horizontal'>
+        <div className='form-group'>
+          <label for='inputEmail3' className='col-sm-2 control-label'>Email</label>
+          <div className='col-sm-10'>
+            <input type='email' className='form-control' id='inputEmail3' placeholder='Email' />
+          </div>
+        </div>
+        <div className='form-group'>
+          <label for='inputPassword3' className='col-sm-2 control-label'>Password</label>
+          <div className='col-sm-10'>
+            <input type='password' className='form-control' id='inputPassword3' placeholder='Password' />
+          </div>
+        </div>
+        <div className='form-group'>
+          <div className='col-sm-offset-2 col-sm-10'>
+            <div className='checkbox'>
+              <label>
+                <input type='checkbox' /> Remember me
+              </label>
+            </div>
+          </div>
+        </div>
+        <div className='form-group'>
+          <div className='col-sm-offset-2 col-sm-10'>
+            <button type='submit' className='btn btn-default'>Sign in</button>
           </div>
         </div>
       </form>

--- a/demo/tatami/src/client/js/components/forms.js
+++ b/demo/tatami/src/client/js/components/forms.js
@@ -87,26 +87,26 @@ export default function Forms () {
         <h4>Inline checkboxes and radios</h4>
         <div className='form-group'>
           <label className='checkbox-inline'>
-            <input type='checkbox' value='option1' /> 1
+            <input type='checkbox' value='option1' /> One
           </label>
           <label className='checkbox-inline'>
-            <input type='checkbox' value='option2' /> 2
+            <input type='checkbox' value='option2' /> Two
           </label>
           <label className='checkbox-inline'>
-            <input type='checkbox' value='option3' /> 3
+            <input type='checkbox' value='option3' /> Three
           </label>
         </div>
 
         <div className='form-group'>
           some text {' '}
           <label className='radio-inline'>
-            <input type='radio' name='inlineRadioOptions' value='option1' /> 1
+            <input type='radio' name='inlineRadioOptions' value='option1' /> One
           </label>
           <label className='radio-inline'>
-            <input type='radio' name='inlineRadioOptions' value='option2' /> 2
+            <input type='radio' name='inlineRadioOptions' value='option2' /> Two
           </label>
           <label className='radio-inline'>
-            <input type='radio' name='inlineRadioOptions' value='option3' /> 3
+            <input type='radio' name='inlineRadioOptions' value='option3' /> Three
           </label>
         </div>
         <br />

--- a/demo/tatami/src/client/js/components/forms.js
+++ b/demo/tatami/src/client/js/components/forms.js
@@ -244,9 +244,6 @@ export default function Forms () {
           <label htmlFor='exampleInputEmail2'>Email</label>
           <input type='email' className='form-control' id='exampleInputEmail2' placeholder='jane.doe@example.com' />
         </div>
-        <div className='form-group'>
-          <p className='form-control-static'>note</p>
-        </div>
         <div className='checkbox'>
           <label>
             <input type='checkbox' /> Remember me
@@ -256,12 +253,6 @@ export default function Forms () {
       </form>
 
       <form className='form-inline'>
-        <div className='form-group'>
-          <input type='text' className='form-control' placeholder='Jane Doe' />
-        </div>
-        <div className='form-group'>
-          <input type='email' className='form-control' placeholder='jane.doe@example.com' />
-        </div>
         <div className='input-group'>
           <span className='input-group-addon'>@</span>
           <input type='text' className='form-control' placeholder='Username' aria-describedby='sizing-addon2' />

--- a/demo/tatami/src/client/js/components/forms.js
+++ b/demo/tatami/src/client/js/components/forms.js
@@ -27,7 +27,7 @@ export default function Forms () {
         <div className='form-group'>
           <label className='control-label' htmlFor='exampleInputPassword1'>Password</label>
           <input type='password' className='form-control' id='exampleInputPassword1' placeholder='Password' />
-          <span id='helpBlock' className='help-block'>
+          <span className='help-block'>
             A block of help text that breaks onto a new line and may extend beyond one line.
           </span>
         </div>
@@ -59,26 +59,26 @@ export default function Forms () {
             <input type='checkbox' /> Check me out
           </label>
         </div>
-        <div className='checkbox'>
+        <div className='checkbox disabled'>
           <label>
-            <input type='checkbox'  disabled /> Disabled check
+            <input type='checkbox' disabled /> Disabled check
           </label>
         </div>
         <div className='radio'>
           <label>
-            <input type='radio' name='optionsRadios' id='optionsRadios1' value='option1' />
+            <input type='radio' name='optionsRadios' value='option1' />
             Option one is this and that&mdash;be sure to include why it's great
           </label>
         </div>
         <div className='radio'>
           <label>
-            <input type='radio' name='optionsRadios' id='optionsRadios2' value='option2' />
+            <input type='radio' name='optionsRadios' value='option2' />
             Option two can be something else and selecting it will deselect option one
           </label>
         </div>
-        <div className='radio'>
+        <div className='radio disabled'>
           <label>
-            <input type='radio' name='optionsRadios' id='optionsRadios2' value='option2' disabled />
+            <input type='radio' name='optionsRadios' value='option2' disabled />
             This option is disabled
           </label>
         </div>
@@ -87,26 +87,26 @@ export default function Forms () {
         <h4>Inline checkboxes and radios</h4>
         <div className='form-group'>
           <label className='checkbox-inline'>
-            <input type='checkbox' id='inlineCheckbox1' value='option1' /> 1
+            <input type='checkbox' value='option1' /> 1
           </label>
           <label className='checkbox-inline'>
-            <input type='checkbox' id='inlineCheckbox2' value='option2' /> 2
+            <input type='checkbox' value='option2' /> 2
           </label>
           <label className='checkbox-inline'>
-            <input type='checkbox' id='inlineCheckbox3' value='option3' /> 3
+            <input type='checkbox' value='option3' /> 3
           </label>
         </div>
 
         <div className='form-group'>
           some text {' '}
           <label className='radio-inline'>
-            <input type='radio' name='inlineRadioOptions' id='inlineRadio1' value='option1' /> 1
+            <input type='radio' name='inlineRadioOptions' value='option1' /> 1
           </label>
           <label className='radio-inline'>
-            <input type='radio' name='inlineRadioOptions' id='inlineRadio2' value='option2' /> 2
+            <input type='radio' name='inlineRadioOptions' value='option2' /> 2
           </label>
           <label className='radio-inline'>
-            <input type='radio' name='inlineRadioOptions' id='inlineRadio3' value='option3' /> 3
+            <input type='radio' name='inlineRadioOptions' value='option3' /> 3
           </label>
         </div>
         <br />
@@ -154,21 +154,21 @@ export default function Forms () {
         <h3>Input groups</h3>
 
         <div className='input-group input-group-lg'>
-          <span className='input-group-addon' id='sizing-addon1'>@</span>
+          <span className='input-group-addon'>@</span>
           <input type='text' className='form-control' placeholder='Username' aria-describedby='sizing-addon1' />
           <span className='input-group-addon'>.00</span>
         </div>
         <br />
 
         <div className='input-group'>
-          <span className='input-group-addon' id='sizing-addon2'>@</span>
+          <span className='input-group-addon'>@</span>
           <input type='text' className='form-control' placeholder='Username' aria-describedby='sizing-addon2' />
           <span className='input-group-addon'>.00</span>
         </div>
         <br />
 
         <div className='input-group input-group-sm'>
-          <span className='input-group-addon' id='sizing-addon3'>@</span>
+          <span className='input-group-addon'>@</span>
           <input type='text' className='form-control' placeholder='Username' aria-describedby='sizing-addon3' />
           <span className='input-group-addon'>.00</span>
         </div>
@@ -237,11 +237,11 @@ export default function Forms () {
       <h2>Inline form</h2>
       <form className='form-inline'>
         <div className='form-group'>
-          <label for='exampleInputName2'>Name</label>
+          <label htmlFor='exampleInputName2'>Name</label>
           <input type='text' className='form-control' id='exampleInputName2' placeholder='Jane Doe' />
         </div>
         <div className='form-group'>
-          <label for='exampleInputEmail2'>Email</label>
+          <label htmlFor='exampleInputEmail2'>Email</label>
           <input type='email' className='form-control' id='exampleInputEmail2' placeholder='jane.doe@example.com' />
         </div>
         <div className='form-group'>
@@ -257,13 +257,13 @@ export default function Forms () {
 
       <form className='form-inline'>
         <div className='form-group'>
-          <input type='text' className='form-control' id='exampleInputName2' placeholder='Jane Doe' />
+          <input type='text' className='form-control' placeholder='Jane Doe' />
         </div>
         <div className='form-group'>
-          <input type='email' className='form-control' id='exampleInputEmail2' placeholder='jane.doe@example.com' />
+          <input type='email' className='form-control' placeholder='jane.doe@example.com' />
         </div>
         <div className='input-group'>
-          <span className='input-group-addon' id='sizing-addon2'>@</span>
+          <span className='input-group-addon'>@</span>
           <input type='text' className='form-control' placeholder='Username' aria-describedby='sizing-addon2' />
           <span className='input-group-addon'>.00</span>
         </div>
@@ -277,13 +277,13 @@ export default function Forms () {
       <h2>Horizontal form</h2>
       <form className='form-horizontal'>
         <div className='form-group'>
-          <label for='inputEmail3' className='col-sm-2 control-label'>Email</label>
+          <label htmlFor='inputEmail3' className='col-sm-2 control-label'>Email</label>
           <div className='col-sm-10'>
             <input type='email' className='form-control' id='inputEmail3' placeholder='Email' />
           </div>
         </div>
         <div className='form-group'>
-          <label for='inputPassword3' className='col-sm-2 control-label'>Password</label>
+          <label htmlFor='inputPassword3' className='col-sm-2 control-label'>Password</label>
           <div className='col-sm-10'>
             <input type='password' className='form-control' id='inputPassword3' placeholder='Password' />
           </div>


### PR DESCRIPTION
boostrap4ではなく、frowcssを参考に custome radioとcheckを実装
checkboxのチェックマークはsvgで作っています。
radioの丸は、borderを広くすることで作っています。

[![Screenshot from Gyazo](https://gyazo.com/7c328c2e1a56976aa0f0cfc1ddb1cc79/raw)](https://gyazo.com/7c328c2e1a56976aa0f0cfc1ddb1cc79)

また、inline-formをflex化しました。
確認のため、inline-formとhorizontal-formをdemoに追加しました。

### 動作確認

以下の環境で、selectとradioがcheckedでもそうでないときも、ちゃんと表示される。
フォーカス表示も表示される。

Mac: Chrome, Firefox, Safari
Windows: Edge, IE11
iOS, Android

@mountainboooy レビューお願いします。


残るは、range (slider) と、 file uploadくらいですね。
なんかbootstrap 4より高機能になってきた。